### PR TITLE
Implemented endpoint consumes mime-type directive

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@
 /spec/reports/
 /tmp/
 sinatra-swagger-exposer-*.gem
+.rvmrc

--- a/lib/sinatra/swagger-exposer/configuration/swagger-endpoint.rb
+++ b/lib/sinatra/swagger-exposer/configuration/swagger-endpoint.rb
@@ -13,7 +13,7 @@ module Sinatra
 
         include SwaggerConfigurationUtilities
 
-        attr_reader :path, :type, :parameters, :responses, :produces
+        attr_reader :path, :type, :parameters, :responses, :produces, :consumes
 
         # @param type [String] the http verb
         # @param sinatra_path [String] the sinatra path
@@ -24,14 +24,15 @@ module Sinatra
         # @param tags [Array<String>] a list of tags
         # @param explicit_path [String] an explicit path if the sinatra path is a regex
         # @param produces [Array<String>] the result types
-        def initialize(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces)
+        # @param consumes [Array<String>] the request types
+        def initialize(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces, consumes)
           @type = type
           @path = swagger_path(sinatra_path, explicit_path)
 
           @parameters = parameters
           @responses = responses
           @produces = produces
-
+          @consumes = consumes
           @attributes = {}
           if summary
             @attributes[:summary] = summary
@@ -44,6 +45,9 @@ module Sinatra
           end
           if produces
             @attributes[:produces] = produces
+          end
+          if consumes
+            @attributes[:consumes] = consumes
           end
         end
 

--- a/lib/sinatra/swagger-exposer/swagger-exposer.rb
+++ b/lib/sinatra/swagger-exposer/swagger-exposer.rb
@@ -33,7 +33,7 @@ module Sinatra
 
       app.set :swagger_processor_creator, Sinatra::SwaggerExposer::SwaggerProcessorCreator.new(swagger_types)
       declare_swagger_endpoint(app)
-      delare_default_error_endpoints(app)
+      declare_default_error_endpoints(app)
     end
 
     # Declare the endpoint to serve the swagger content
@@ -67,7 +67,7 @@ module Sinatra
 
     # Declare default error endpoints
     # @param [Sinatra::Base]
-    def self.delare_default_error_endpoints(app)
+    def self.declare_default_error_endpoints(app)
       app.set :show_execptions, false
       app.error(Sinatra::SwaggerExposer::SwaggerInvalidException) do |e|
         content_type :json

--- a/lib/sinatra/swagger-exposer/swagger-request-processor-creator.rb
+++ b/lib/sinatra/swagger-exposer/swagger-request-processor-creator.rb
@@ -27,7 +27,8 @@ module Sinatra
       # @param swagger_endpoint [Sinatra::SwaggerExposer::Configuration::SwaggerEndpoint] the endpoint
       # @return [Sinatra::SwaggerExposer::Processing::SwaggerRequestProcessor]
       def create_request_processor(swagger_endpoint)
-        request_processor = Sinatra::SwaggerExposer::Processing::SwaggerRequestProcessor.new(swagger_endpoint.produces)
+        request_processor = Sinatra::SwaggerExposer::Processing::SwaggerRequestProcessor.new(swagger_endpoint.produces,
+                                                                                             swagger_endpoint.consumes)
 
         swagger_endpoint.parameters.each do |parameter|
           if TYPE_FILE == parameter.type

--- a/test/test-swagger-request-processor-creator.rb
+++ b/test/test-swagger-request-processor-creator.rb
@@ -12,12 +12,13 @@ class TestSwaggerRequestProcessorCreator < Minitest::Test
 
     class FakeSwaggerEndpointForTestSwaggerRequestProcessorCreator
 
-      attr_reader :parameters, :produces, :responses
+      attr_reader :parameters, :produces, :responses, :consumes
 
-      def initialize(parameters, responses = {}, produces = [])
+      def initialize(parameters, responses = {}, produces = [], consumes = [])
         @parameters = parameters
         @responses = responses
         @produces = produces
+        @consumes = consumes
       end
 
     end
@@ -33,13 +34,13 @@ class TestSwaggerRequestProcessorCreator < Minitest::Test
 
     end
 
-    def create_request_processor(types, parameters, responses = {}, produces = [])
+    def create_request_processor(types, parameters, responses = {}, produces = [], consumes = [])
       swagger_types = Sinatra::SwaggerExposer::Configuration::SwaggerTypes.new
       types.each_pair do |name, param|
         swagger_types.add_type name, param
       end
       processor_creator = Sinatra::SwaggerExposer::SwaggerProcessorCreator.new(swagger_types)
-      swagger_endpoint = FakeSwaggerEndpointForTestSwaggerRequestProcessorCreator.new(parameters, responses, produces)
+      swagger_endpoint = FakeSwaggerEndpointForTestSwaggerRequestProcessorCreator.new(parameters, responses, produces, consumes)
       processor_creator.create_request_processor(swagger_endpoint)
     end
 
@@ -66,6 +67,10 @@ class TestSwaggerRequestProcessorCreator < Minitest::Test
 
     it 'transmits the produeces param' do
       create_request_processor({}, [], {}, ['image/png']).produces.must_equal ['image/png']
+    end
+
+    it 'transmits the consumes param' do
+      create_request_processor({},[],{},['text/plain'], ['text/plain']).consumes.must_equal ['text/plain']
     end
 
     it 'deal with useless request processor' do

--- a/test/test-utilities.rb
+++ b/test/test-utilities.rb
@@ -23,9 +23,9 @@ module TestUtilities
     Sinatra::SwaggerExposer::Configuration::SwaggerType.new(type_name, type_properties, known_types)
   end
 
-  def new_e(type, sinatra_path, parameters = [], responses = {}, summary = nil, description = nil, tags = nil, explicit_path = nil, produces = nil)
+  def new_e(type, sinatra_path, parameters = [], responses = {}, summary = nil, description = nil, tags = nil, explicit_path = nil, produces = nil, consumes = nil)
     require_relative '../lib/sinatra/swagger-exposer/configuration/swagger-endpoint'
-    Sinatra::SwaggerExposer::Configuration::SwaggerEndpoint.new(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces)
+    Sinatra::SwaggerExposer::Configuration::SwaggerEndpoint.new(type, sinatra_path, parameters, responses, summary, description, tags, explicit_path, produces, consumes)
   end
 
   def new_ep(name, description, how_to_pass, required, type, params = {}, known_types = [])


### PR DESCRIPTION
* endpoint documents and validates 'consumes' directive, defaulting to application/json
* render SwaggerInvalidException in a sinatra error handler, which can be overridden in application.